### PR TITLE
Cleanups

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,7 +7,7 @@ compression: lzo
 architectures:
   - build-on: amd64
   - build-on: arm64
-  - build-on: arm64
+  - build-on: armhf
 
 layout:
   /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.1:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -6,7 +6,8 @@ confinement: strict
 compression: lzo
 architectures:
   - build-on: amd64
-    build-for: amd64
+  - build-on: arm64
+  - build-on: arm64
 
 layout:
   /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.1:
@@ -14,7 +15,7 @@ layout:
 
 environment:
   # WORKAROUND: Add python modules in Snap to search path
-  PYTHONPATH: ${SNAP}/lib/python3.10/site-packages:${SNAP}/usr/lib/python3/dist-packages
+  PYTHONPATH: $PYTHONPATH:${SNAP}/usr/lib/python3/dist-packages
 
 slots:
   wike:
@@ -27,13 +28,10 @@ apps:
     command: usr/bin/wike
     extensions: [gnome]
     plugs:
-      - home
       - audio-playback
       - network
       - network-status
-      - network-bind
-      - optical-drive
-      - removable-media
+      - unity7
     common-id: com.github.hugolabe.Wike
     desktop: usr/share/applications/com.github.hugolabe.Wike.desktop
         
@@ -45,13 +43,15 @@ parts:
     parse-info: [usr/share/metainfo/com.github.hugolabe.Wike.metainfo.xml]
     meson-parameters:
       - --prefix=/snap/wike/current/usr
-    override-pull: |
-      craftctl default
-      craftctl set version=$(git describe --tags --abbrev=0)
+    stage-packages:
+      - python3-dbus
+      - python3-requests
     override-build: |
       craftctl default
       # WORKAROUND: Use python from search path, the path detected by meson doesn't exist when running the Snap
       sed -e '1c#!/usr/bin/env python3' -i ${CRAFT_PART_INSTALL}/snap/wike/current/usr/bin/wike
+      rm -rf usr/share/man
+      rm -rf usr/share/doc
     organize:
       snap/wike/current/usr: usr  
     


### PR DESCRIPTION
1. Removed the version setup, they are auto updated from appstream metafiles. No need to manually set them.
2. Stage the python deps (https://github.com/hugolabe/Wike/blob/1.8.3/build-aux/flatpak)
3. Don't add `home` plug everywhere, not necessary for apps like this.